### PR TITLE
Conditionally include the category name in the post title

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,8 +2,9 @@ en:
   site_settings:
     slack_enabled: 'Check this to enable the Slack integration.'
     slack_url: 'Slack URL including access token.'
-    slack_channel: 'Slack channel to post this message to. (i.e. #general, @username)'
+    slack_channel: 'Slack channel to post this message to. (i.e. #general, @username). Leaving blank for no fallback is helpful if using "allow category slack channel" setting.'
     slack_emoji: 'Slack emoji to use.'
     slack_posts: 'Post all new posts to Slack (not just new topics).'
     slack_full_names: 'Shows user full names instead of usernames (shows username if user did not set one)'
     allow_category_slack_channel: 'Allows each category to specify a Slack channel to post to, falls back to parent categories or the global channel'
+    slack_category_name_in_title: 'Display the category name in the title of the post sent to Slack (e.g., "[category name] topic title")'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,6 @@ slack:
   allow_category_slack_channel:
     client: true
     default: false
+  slack_category_name_in_title:
+    client: true
+    default: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,6 +46,8 @@ after_initialize do
         end
       end
 
+      next if channel.blank?
+
       request = Net::HTTP::Post.new(uri.path)
       request.add_field('Content-Type', 'application/json')
       request.body = {

--- a/plugin.rb
+++ b/plugin.rb
@@ -28,9 +28,9 @@ after_initialize do
       # Default to the global site channel
       channel = SiteSetting.slack_channel
 
+      category = topic.category
       # We might have a category specific channel to post to
       if SiteSetting.allow_category_slack_channel
-        category = topic.category
 
         # We walk up the categories to the root unless we find a
         # channel setting on the category
@@ -48,6 +48,8 @@ after_initialize do
 
       next if channel.blank?
 
+      show_category_name = SiteSetting.slack_category_name_in_title
+
       request = Net::HTTP::Post.new(uri.path)
       request.add_field('Content-Type', 'application/json')
       request.body = {
@@ -58,7 +60,7 @@ after_initialize do
           {
             :fallback => "New " + (post.try(:is_first_post?) ? "topic" : "post in #{topic.title}") + " by #{display_name} - #{post_url}",
             :pretext => "New " + (post.try(:is_first_post?) ? "topic" : "post") + " by #{display_name}:",
-            :title => topic.title,
+            :title => (show_category_name ? "[" + category.name + "] " : "") + topic.title,
             :title_link => post_url,
             :text => post.excerpt(200, text_entities: false, strip_links: true)
           }


### PR DESCRIPTION
This adds a setting to show the category title in what is posted to Slack, like "[category name] topic title". 

It also includes @richardxia's commit that will allow for no posting if there's no Slack channel specified.

I guess this is getting kind of messy. I'm submitting this to your master branch instead of as its own PR to to the source repo because it relies on pulling `category` out of the `if` block from your PR. This gets messy I guess, especially since your PR is from your master branch... let me know if you'd rather I do something else with it. If you all would rather I break this up into smaller chunks I could do that. 

Convenience link: https://github.com/bernd/discourse-slack-plugin/pull/7